### PR TITLE
Fix Duplicate Key and MySQL Column issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+
+python:
+  - "3.3"
+  - "3.4"
+  - "3.5"
+
+before_script:
+  - mysql -e 'create database travis_ci_test;'
+  - psql -c 'create database travis_ci_test;' -U postgres
+
+install:
+  - pip install --upgrade pip
+  - pip install -r requirements.txt
+  - pip install errbot psycopg2 pymysql pytest pytest-pep8
+
+services:
+  - mysql
+  - postgresql
+
+script: py.test --pep8

--- a/sql.py
+++ b/sql.py
@@ -98,8 +98,8 @@ class SQLPlugin(StoragePluginBase):
 
         # Create a table with the given namespace
         table = Table(namespace, self._metadata,
-                      Column('key', String(), primary_key=True),
-                      Column('value', String()),
+                      Column('key', String(255), primary_key=True),
+                      Column('value', String(32768)),
                       extend_existing=True)
 
         class NewKV(KV):

--- a/sql.py
+++ b/sql.py
@@ -51,7 +51,7 @@ class SQLStorage(StorageBase):
             raise KeyError("%s doesn't exists." % key)
 
     def set(self, key: str, value: Any) -> None:
-        self.session.add(self.clazz(key, value))
+        self.session.merge(self.clazz(key, value))
         self.session.commit()
 
     def len(self):
@@ -99,7 +99,8 @@ class SQLPlugin(StoragePluginBase):
         # Create a table with the given namespace
         table = Table(namespace, self._metadata,
                       Column('key', String(), primary_key=True),
-                      Column('value', String()))
+                      Column('value', String()),
+                      extend_existing=True)
 
         class NewKV(KV):
             pass

--- a/sql.py
+++ b/sql.py
@@ -3,7 +3,9 @@
 import logging
 from jsonpickle import encode, decode
 from typing import Any
-from sqlalchemy import Table, MetaData, Column, Integer, String, ForeignKey, create_engine, select
+from sqlalchemy import (
+    Table, MetaData, Column, Integer, String,
+    ForeignKey, create_engine, select)
 from sqlalchemy.orm import mapper, sessionmaker
 from sqlalchemy.orm.exc import NoResultFound
 from errbot.storage.base import StorageBase, StoragePluginBase
@@ -15,7 +17,7 @@ DATA_URL_ENTRY = 'data_url'
 
 class KV(object):
     """This is a basic key/value. Pickling in JSON."""
-    def __init__(self, key:str, value:Any):
+    def __init__(self, key: str, value: Any):
         self._key = key
         self._value = encode(value)
 
@@ -35,19 +37,21 @@ class SQLStorage(StorageBase):
 
     def get(self, key: str) -> Any:
         try:
-            return self.session.query(self.clazz).filter(self.clazz._key == key).one().value
+            return self.session.query(
+                self.clazz).filter(self.clazz._key == key).one().value
         except NoResultFound:
             raise KeyError("%s doesn't exists." % key)
 
     def remove(self, key: str):
         try:
-            self.session.query(self.clazz).filter(self.clazz._key == key).delete()
+            self.session.query(
+                self.clazz).filter(self.clazz._key == key).delete()
             self.session.commit()
         except NoResultFound:
             raise KeyError("%s doesn't exists." % key)
 
     def set(self, key: str, value: Any) -> None:
-        self.session.add(self.clazz(key,value))
+        self.session.add(self.clazz(key, value))
         self.session.commit()
 
     def len(self):
@@ -65,41 +69,44 @@ class SQLPlugin(StoragePluginBase):
         super().__init__(bot_config)
         config = self._storage_config
         if DATA_URL_ENTRY not in config:
-            raise Exception('You need to specify an connection URL for the database in data_url in you config.py for example:\n'
-                            'STORAGE_CONFIG={\n'
-                            '"data_url": "postgresql://scott:tiger@localhost/mydatabase/",\n'
-                            '}')
+            raise Exception(
+                'You need to specify a connection URL for the database in your'
+                'config.py. For example:\n'
+                'STORAGE_CONFIG={\n'
+                '"data_url": "postgresql://'
+                'scott:tiger@localhost/mydatabase/",\n'
+                '}')
 
         # Hack around the multithreading issue in memory only sqlite.
         # This mode is useful for testing.
         if config[DATA_URL_ENTRY] == 'sqlite://':
             from sqlalchemy.pool import StaticPool
-            self._engine = create_engine('sqlite://',
-                    connect_args={'check_same_thread':False},
-                    poolclass=StaticPool,
-                    echo=bot_config.BOT_LOG_LEVEL == logging.DEBUG)
+            self._engine = create_engine(
+                'sqlite://',
+                connect_args={'check_same_thread': False},
+                poolclass=StaticPool,
+                echo=bot_config.BOT_LOG_LEVEL == logging.DEBUG)
         else:
-            self._engine = create_engine(config[DATA_URL_ENTRY], echo=bot_config.BOT_LOG_LEVEL == logging.DEBUG)
+            self._engine = create_engine(
+                config[DATA_URL_ENTRY],
+                echo=bot_config.BOT_LOG_LEVEL == logging.DEBUG)
         self._metadata = MetaData()
         self._sessionmaker = sessionmaker()
         self._sessionmaker.configure(bind=self._engine)
-
 
     def open(self, namespace: str) -> StorageBase:
 
         # Create a table with the given namespace
         table = Table(namespace, self._metadata,
-                Column('key', String(), primary_key=True),
-                Column('value', String()),
-                )
+                      Column('key', String(), primary_key=True),
+                      Column('value', String()))
 
         class NewKV(KV):
             pass
 
         mapper(NewKV, table, properties={
             '_key': table.c.key,
-            '_value': table.c.value,
-            })
+            '_value': table.c.value})
 
         # ensure that the table for this namespace exists
         self._metadata.create_all(self._engine)

--- a/sql.py
+++ b/sql.py
@@ -79,10 +79,10 @@ class SQLPlugin(StoragePluginBase):
 
         # Hack around the multithreading issue in memory only sqlite.
         # This mode is useful for testing.
-        if config[DATA_URL_ENTRY] == 'sqlite://':
+        if config[DATA_URL_ENTRY].startswith('sqlite://'):
             from sqlalchemy.pool import StaticPool
             self._engine = create_engine(
-                'sqlite://',
+                config[DATA_URL_ENTRY],
                 connect_args={'check_same_thread': False},
                 poolclass=StaticPool,
                 echo=bot_config.BOT_LOG_LEVEL == logging.DEBUG)

--- a/tests/storagetest_plugin/storagetest.plug
+++ b/tests/storagetest_plugin/storagetest.plug
@@ -1,0 +1,6 @@
+[Core]
+Name = Storagetest
+Module = storagetest
+
+[Python]
+Version = 3

--- a/tests/storagetest_plugin/storagetest.py
+++ b/tests/storagetest_plugin/storagetest.py
@@ -1,0 +1,9 @@
+from errbot import BotPlugin
+
+
+class Storagetest(BotPlugin):
+    """
+    Just a plugin with a simple string config.
+    """
+    def get_configuration_template(self):
+        return {'StorageType': 'Unconfigured'}

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,86 @@
+import py
+import pytest
+import shutil
+import tempfile
+from errbot.backends.test import testbot
+from os import path
+
+STORAGE_CONFIG = {
+    'StorageType': 'Memory'
+}
+extra_plugin_dir = path.join(path.dirname(path.realpath(__file__)),
+                             'storagetest_plugin')
+
+
+def connect_string(dialect):
+    return {
+        'mysql': 'mysql+pymysql://travis:@localhost/travis_ci_test',
+        'postgres': 'postgresql://postgres:@localhost/travis_ci_test',
+        'sqlite': 'sqlite:////tmp/errbot.db',
+    }[dialect]
+
+
+def config(dialect, restore=False):
+    return {
+        'STORAGE': 'SQL',
+        'BOT_EXTRA_STORAGE_PLUGINS_DIR': path.join(
+            path.dirname(path.realpath(__file__)), '..'),
+        'STORAGE_CONFIG': {
+            "data_url": connect_string(dialect)}}
+
+
+@pytest.fixture(scope='session')
+def sessiondir(request):
+    d = py.path.local(tempfile.mkdtemp())
+    request.addfinalizer(lambda: d.remove(rec=1))
+    return d
+
+
+@pytest.fixture
+def restore_path(sessiondir):
+    return sessiondir
+
+
+@pytest.fixture
+def restore_file(sessiondir):
+    return '{}/backup.py'.format(sessiondir)
+
+
+def test_run_backup(testbot, restore_file):
+    backup_file = testbot.bot_config.BOT_DATA_DIR + '/backup.py'
+    assert 'Plugin configuration done.' in testbot.exec_command(
+        '!plugin config Storagetest {!r}'.format(STORAGE_CONFIG))
+
+    assert '{!r}'.format(STORAGE_CONFIG) in \
+        testbot.exec_command('!plugin config Storagetest')
+
+    assert "The backup file has been written in '{}'".format(backup_file) in \
+        testbot.exec_command('!backup')
+
+    shutil.copy2(backup_file, restore_file)
+
+
+restore_backup = True
+
+extra_config = config('mysql')
+
+
+def test_mysql_storage(testbot):
+    assert '{!r}'.format(STORAGE_CONFIG) in \
+        testbot.exec_command('!plugin config Storagetest')
+
+
+extra_config = config('sqlite')
+
+
+def test_sqlite_storage(testbot):
+    assert '{!r}'.format(STORAGE_CONFIG) in \
+        testbot.exec_command('!plugin config Storagetest')
+
+
+extra_config = config('postgres')
+
+
+def test_postgres_storage(testbot):
+    assert '{!r}'.format(STORAGE_CONFIG) in \
+        testbot.exec_command('!plugin config Storagetest')


### PR DESCRIPTION
PR Attempt to resolve some outstanding issues - The tests are currently very broken and I need some feedback. They involved making this change in the errbot source in an attempt to test backups/restores:

``` shell
diff --git a/errbot/backends/test.py b/errbot/backends/test.py
index dd0b5fd..def42ef 100644
--- a/errbot/backends/test.py
+++ b/errbot/backends/test.py
@@ -343,10 +343,13 @@ class TestBot(object):
     """
     bot_thread = None

-    def __init__(self, extra_plugin_dir=None, loglevel=logging.DEBUG, extra_config=None):
-        self.setup(extra_plugin_dir=extra_plugin_dir, loglevel=loglevel, extra_config=extra_config)
+    def __init__(self, extra_plugin_dir=None, loglevel=logging.DEBUG,
+                 extra_config=None, restore_backup=None):
+        self.setup(extra_plugin_dir=extra_plugin_dir, loglevel=loglevel,
+                   extra_config=extra_config, restore_backup=restore_backup)

-    def setup(self, extra_plugin_dir=None, loglevel=logging.DEBUG, extra_config=None):
+    def setup(self, extra_plugin_dir=None, loglevel=logging.DEBUG,
+              extra_config=None, restore_backup=None):
         """
         :param extra_config: Piece of extra configuration you want to inject to the config.
         :param extra_plugin_dir: Path to a directory from which additional
@@ -354,7 +357,12 @@ class TestBot(object):
         :param loglevel: Logging verbosity. Expects one of the constants
             defined by the logging module.
         """
-        tempdir = mkdtemp()
+        if restore_backup:
+            self.restore = True
+            tempdir = restore_backup
+        else:
+            self.restore = False
+            tempdir = mkdtemp()

         # This is for test isolation.
         config = ShallowConfig()
@@ -388,7 +396,7 @@ class TestBot(object):
         """
         if self.bot_thread is not None:
             raise Exception("Bot has already been started")
-        self._bot = setup_bot('Test', self.logger, self.bot_config)
+        self._bot = setup_bot('Test', self.logger, self.bot_config, self.restore)
         self.bot_thread = Thread(target=self.bot.serve_forever, name='TestBot main thread')
         self.bot_thread.setDaemon(True)
         self.bot_thread.start()
```

Which seems terrible, but i'm not sure on the best way to achieve this.  Furthermore, the bot state isn't properly reloaded between tests, so I guess I could run run py.test separately three times but that also seems super hacky... Thoughts?
